### PR TITLE
Data Json Merging Support for Mods

### DIFF
--- a/InteractionsPlus.csproj
+++ b/InteractionsPlus.csproj
@@ -7,7 +7,7 @@
         <AssemblyVersion>0.1.0</AssemblyVersion>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PropertyGroup>
       <OutputPath>D:\SteamLibrary\steamapps\common\Ostranauts\Mods\InteractionsPlus\</OutputPath>
     </PropertyGroup>
 

--- a/InteractionsPlusMod.UMM.cs
+++ b/InteractionsPlusMod.UMM.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using InteractionsPlus.ModDependency;
 using InteractionsPlus.UI.IMGUI;
 using JetBrains.Annotations;
 using UnityModManagerNet;
@@ -34,7 +35,12 @@ namespace InteractionsPlus
             {
                 guiExecutor = executor;
             }
-            
+
+            if (InteractionsPlusMod.Services.TryResolve(out UMMDependencyManager dependencyManager))
+            {
+                dependencyManager.SetModList(UnityModManager.modEntries);
+            }
+
             return true;
         }
 

--- a/InteractionsPlusMod.cs
+++ b/InteractionsPlusMod.cs
@@ -1,6 +1,8 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using HarmonyLib;
 using InteractionsPlus.Handlers;
+using InteractionsPlus.ModDependency;
 using InteractionsPlus.UI.IMGUI;
 using JetBrains.Annotations;
 
@@ -8,6 +10,8 @@ namespace InteractionsPlus
 {
     public class InteractionsPlusMod
     {
+        public const string ModId = "InteractionsPlus";
+        
         [NotNull] public static readonly ServiceLocator Services = new ServiceLocator(); 
         
         [NotNull] private readonly ILogger logger;
@@ -17,12 +21,14 @@ namespace InteractionsPlus
         [NotNull] private readonly HandlerManager handlerManager;
         [NotNull] private readonly InteractionAdditionalActionsManager additionalDataManager;
         
+        [NotNull] private readonly UMMDependencyManager dependencyManager;
         internal InteractionsPlusMod([NotNull]ILogger logger)
         {
             this.logger = logger;
             handlerManager = new HandlerManager(logger);
             additionalDataManager = new InteractionAdditionalActionsManager();
             immediateGUIExecutor = new IMGUIExecutor();
+            dependencyManager = new UMMDependencyManager(logger);
             harmony = new Harmony("com.ostranauts.marchingninja.interactionsplus");
 
             Services.SetLogger(logger);
@@ -30,6 +36,7 @@ namespace InteractionsPlus
             Services.Bind<HandlerManager>(handlerManager);
             Services.Bind<InteractionAdditionalActionsManager>(additionalDataManager);
             Services.Bind<IMGUIExecutor>(immediateGUIExecutor);
+            Services.Bind<UMMDependencyManager>(dependencyManager);
         }
         
         public bool OnToggle(bool toggle)

--- a/InteractionsPlusMod.cs
+++ b/InteractionsPlusMod.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using HarmonyLib;
 using InteractionsPlus.Handlers;
+using InteractionsPlus.JsonMerging;
 using InteractionsPlus.ModDependency;
 using InteractionsPlus.UI.IMGUI;
 using JetBrains.Annotations;
@@ -20,8 +21,9 @@ namespace InteractionsPlus
         [NotNull] private readonly IMGUIExecutor immediateGUIExecutor;
         [NotNull] private readonly HandlerManager handlerManager;
         [NotNull] private readonly InteractionAdditionalActionsManager additionalDataManager;
-        
         [NotNull] private readonly UMMDependencyManager dependencyManager;
+        [NotNull] private readonly MergedJsonDataManager mergedJsonManager;
+
         internal InteractionsPlusMod([NotNull]ILogger logger)
         {
             this.logger = logger;
@@ -29,6 +31,8 @@ namespace InteractionsPlus
             additionalDataManager = new InteractionAdditionalActionsManager();
             immediateGUIExecutor = new IMGUIExecutor();
             dependencyManager = new UMMDependencyManager(logger);
+            mergedJsonManager = new MergedJsonDataManager(logger);
+            
             harmony = new Harmony("com.ostranauts.marchingninja.interactionsplus");
 
             Services.SetLogger(logger);
@@ -37,6 +41,7 @@ namespace InteractionsPlus
             Services.Bind<InteractionAdditionalActionsManager>(additionalDataManager);
             Services.Bind<IMGUIExecutor>(immediateGUIExecutor);
             Services.Bind<UMMDependencyManager>(dependencyManager);
+            Services.Bind<MergedJsonDataManager>(mergedJsonManager);
         }
         
         public bool OnToggle(bool toggle)
@@ -55,6 +60,7 @@ namespace InteractionsPlus
         private void EnableMod()
         {
             handlerManager.DisoverHandlersInAllAssemblies();
+            mergedJsonManager.Initialized();
             
             harmony.PatchAll(Assembly.GetExecutingAssembly());
             logger.Log("Interactions+ enabled");

--- a/JsonMerging/JsonDataSource.cs
+++ b/JsonMerging/JsonDataSource.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal class JsonDataSource
+    {
+        public readonly string Path;
+        public readonly Type JsonType;
+        public readonly Action<string, object> AppendAction;
+            
+        public JsonDataSource(string path, Type type, Action<string,object> appendAction)
+        {
+            Path = path;
+            JsonType = type;
+            AppendAction = appendAction;
+        }
+    }
+}

--- a/JsonMerging/JsonDataSource.cs
+++ b/JsonMerging/JsonDataSource.cs
@@ -14,5 +14,18 @@ namespace InteractionsPlus.JsonMerging
             JsonType = type;
             AppendAction = appendAction;
         }
+
+        public void ParseModPath(string modPath)
+        {
+            ParseDataSource(modPath, this);
+        }
+        
+        private void ParseDataSource(string modPath, JsonDataSource dataSource)
+        {
+            var jsonPath = dataSource.Path;
+            var parseDelegate = JsonParsingUtils.GetParseAdditionalJsonInPathAndAppendTypeless(dataSource.JsonType);
+            parseDelegate(modPath,  jsonPath, dataSource.AppendAction);
+        }
+        
     }
 }

--- a/JsonMerging/JsonDataSource.cs
+++ b/JsonMerging/JsonDataSource.cs
@@ -2,7 +2,7 @@
 
 namespace InteractionsPlus.JsonMerging
 {
-    internal class JsonDataSource
+    internal abstract class JsonDataSource
     {
         public readonly string Path;
         public readonly Type JsonType;
@@ -17,15 +17,9 @@ namespace InteractionsPlus.JsonMerging
 
         public void ParseModPath(string modPath)
         {
-            ParseDataSource(modPath, this);
+            ParseDataSource(modPath);
         }
-        
-        private void ParseDataSource(string modPath, JsonDataSource dataSource)
-        {
-            var jsonPath = dataSource.Path;
-            var parseDelegate = JsonParsingUtils.GetParseAdditionalJsonInPathAndAppendTypeless(dataSource.JsonType);
-            parseDelegate(modPath,  jsonPath, dataSource.AppendAction);
-        }
-        
+
+        protected abstract void ParseDataSource(string modPath);
     }
 }

--- a/JsonMerging/JsonDataSourceCollection.cs
+++ b/JsonMerging/JsonDataSourceCollection.cs
@@ -6,12 +6,13 @@ using JetBrains.Annotations;
 
 namespace InteractionsPlus.JsonMerging
 {
-    internal class JsonDataSourceCollection : IEnumerable<JsonDataSource>
+    internal class JsonDataSourceCollection
     {
-        private const string DataPath = "data/";
+        private const string DataPath = "data\\";
         
         [NotNull] private readonly ILogger logger;
-        [NotNull] private readonly List<JsonDataSource> jsonPathToDataPath = new List<JsonDataSource>();
+        [NotNull] private readonly List<SimplePostfixOnlyDataSource> postFixOnlyDataSource = new List<SimplePostfixOnlyDataSource>();
+        [NotNull] private readonly Dictionary<string, PostProcessedDataSource> postProcessedDataSources = new Dictionary<string, PostProcessedDataSource>();
 
         public JsonDataSourceCollection([NotNull] ILogger logger)
         {
@@ -26,78 +27,65 @@ namespace InteractionsPlus.JsonMerging
             AddDataSource<JsonLight>("lights.json","dictLights");
             AddDataSource<JsonGasRespire>("gasrespires.json","dictGasRespires");
             AddDataSource<JsonPowerInfo>("powerinfos.json","dictPowerInfo");
-            AddDataSource<JsonGUIPropMap>("guipropmaps.json","dictGUIPropMapUnparsed");
-            // DataHandler.ParseGUIPropMaps();
+            AddDataSource<JsonGUIPropMap>("guipropmaps.json","dictGUIPropMapUnparsed", postParseMethod: "ParseGUIPropMaps");
             AddDataSource<JsonCond>("conditions.json","dictConds");
-            AddDataSource<JsonSimple>("conditions_simple.json","dictSimple");
-            // ParseConditionsSimple();
+            AddSimpleSource("conditions_simple.json","ParseConditionsSimple");
             AddDataSource<JsonItemDef>("items.json", "dictItemDefs");
             AddDataSource<CondTrigger>("condtrigs.json", "dictCTs");
             AddDataSource<JsonInteraction>("interactions.json", "dictInteractions");
             AddDataSource<JsonCondOwner>("condowners.json", "dictCOs");
-            //DataHandler.LoadShips();
+            
+            //DataHandler.LoadShips(); // Multi json source
+
             AddDataSource<JsonCondOwner>("loot.json", "dictLoot");
             //DataHandler.TxtToData(DataHandler.strAssetPath + DataHandler.strDataPath + "names_last.json", DataHandler.aNamesLast);
             //DataHandler.dictSimple.Clear();
-            AddDataSource<JsonCondOwner>("names_first.json", "dictSimple");
-            //DataHandler.ParseFirstNames();
+            AddSimpleSource("names_first.json", "ParseFirstNames");
             AddDataSource<JsonHomeworld>("homeworlds.json", "dictHomeworlds");
             AddDataSource<JsonCareer>("careers.json", "dictCareers");
             AddDataSource<JsonLifeEvent>("lifeevents.json", "dictLifeEvents");
             AddDataSource<JsonPersonSpec>("personspecs.json", "dictPersonSpecs");
             //DataHandler.dictSimple.Clear();
-            AddDataSource<JsonSimple>("traitscores.json", "dictSimple");
-            //DataHandler.ParseTraitScores();
+            AddSimpleSource("traitscores.json", "ParseTraitScores");
             //DataHandler.dictSimple.Clear();
-            AddDataSource<JsonSimple>( "strings.json","dictSimple");
-            //DataHandler.ParseGameStrings();
+            AddSimpleSource("strings.json","ParseGameStrings");
             AddDataSource<JsonPlot>("plots.json", "dictPlots");
             AddDataSource<JsonSlot>("slots.json", "dictSlots");
             AddDataSource<JsonTicker>("tickers.json", "dictTickers");
             AddDataSource<CondRule>("condrules.json", "dictCondRules");
             AddDataSource<JsonAudioEmitter>( "audioemitters.json","dictAudioEmitters");
             //DataHandler.dictSimple.Clear();
-            AddDataSource<JsonSimple>("crewskins.json", "dictSimple");
-            //DataHandler.ParseCrewSkins();
+            AddSimpleSource("crewskins.json", "ParseCrewSkins");
             AddDataSource<JsonAd>("ads.json", "dictAds");
             AddDataSource<JsonHeadline>("headlines.json", "dictHeadlines");
-            AddDataSource<JsonMusic>( "music.json", "dictMusic");
             AddDataSource<JsonComputerEntry>("computerentries.json", "dictComputerEntries");
-            //DataHandler.ParseMusic();
+            AddDataSource<JsonMusic>("music.json", "dictMusic", "ParseMusic");
             AddDataSource<JsonCOOverlay>("cooverlays.json", "dictCOOverlays");
             //DataHandler.dictSimple.Clear();
-            AddDataSource<JsonSimple>("names_ship.json", "dictSimple");
-            //DataHandler.ParseShipNames();
+            AddSimpleSource("names_ship.json", "ParseShipNames");
             //DataHandler.dictSimple.Clear();
-            //DataHandler.ParseGeneratedShipNames();
+            
+            //DataHandler.ParseGeneratedShipNames();  // Multi json
+            
             AddDataSource<CondTrigger>("condtrigs2.json", "dictCTs");
-            AddDataSource<JsonInteraction>("interactions2.json", "dictSocials");
-            //DataHandler.dictSocialStats = new Dictionary<string, SocialStats>();
-            //foreach (JsonInteraction jsonInteraction in DataHandler.dictSocials.Values)
-            //{
-            //    DataHandler.dictInteractions[jsonInteraction.strName] = jsonInteraction;
-            //    DataHandler.dictSocialStats[jsonInteraction.strName] = new SocialStats(jsonInteraction.strName);
-            //}
-            //Dictionary<string, JsonInstallable> dict = new Dictionary<string, JsonInstallable>();
-            //DataHandler.JsonToData<JsonInstallable>(DataHandler.strAssetPath + DataHandler.strDataPath + "installables.json", dict);
-            //foreach (KeyValuePair<string, JsonInstallable> keyValuePair in dict)
-            //    Installables.Create(keyValuePair.Value);
-            //dict.Clear();
-            //if (File.Exists(Application.persistentDataPath + "/settings.json"))
-            //    DataHandler.JsonToData<JsonSetting>(Application.persistentDataPath + "/settings.json", DataHandler.dictSettings);
-            //DataHandler.bLoaded = true;
+            
+            // Special handling of interaction2.json
+            postFixOnlyDataSource.Add(new SimplePostfixOnlyDataSource(DataPath+"interactions2.json", typeof(JsonInteraction), AppendSocialInteraction));
+            postFixOnlyDataSource.Add(new SimplePostfixOnlyDataSource(DataPath+"installables.json", typeof(JsonInstallable), AppendInstallable));
+            
+            AddSource<JsonSetting>("settings.json", "dictSettings");
             
             
             void Append<T>(string key, object typelessJson, string dictionaryName)
             {
                 T typeJson = (T) typelessJson;
 
-                if (!dictionaryFieldList.TryGetValue(dictionaryName, out FieldInfo field))
+                Dictionary<string, T> dictionary = GetDictionary<T>(dictionaryName);
+                if (dictionary == null)
                 {
                     return;
                 }
                 
-                Dictionary<string, T> dictionary = GetDictionary<T>(field);
                 if (dictionary.ContainsKey(key))
                 {
                     logger.Error($"Cannot append {key}. Key already exists.");
@@ -107,24 +95,77 @@ namespace InteractionsPlus.JsonMerging
                 
                 dictionary.Add(key, typeJson);
             }
+            
+            void AppendSocialInteraction(string key, object typelessJson)
+            {
+                if (typelessJson == null)
+                {
+                    return;
+                }
+                
+                Append<JsonInteraction>(key, typelessJson, "dictSocials");
 
-            Dictionary<string, T> GetDictionary<T>(FieldInfo field)
+                JsonInteraction jsonInteraction =  (JsonInteraction) typelessJson;
+                
+                Dictionary<string, JsonInteraction> interactionsDict = GetDictionary<JsonInteraction>("dictInteractions");
+                Dictionary<string, SocialStats> socialStatsDict = GetDictionary<SocialStats>("dictSocialStats");
+                if (interactionsDict == null || socialStatsDict == null)
+                {
+                    return;
+                }
+                interactionsDict[jsonInteraction.strName] = jsonInteraction;
+                socialStatsDict[jsonInteraction.strName] = new SocialStats(jsonInteraction.strName);
+            }
+
+            void AppendInstallable(string key, object typelessJson)
+            {
+                JsonInstallable installable = (JsonInstallable) typelessJson;
+                
+                Installables.Create(installable);
+            }
+            
+
+            Dictionary<string, T> GetDictionary<T>(string dictionaryName)
+            {
+                if (!dictionaryFieldList.TryGetValue(dictionaryName, out FieldInfo field))
+                {
+                    logger.Error($"Cannot find data dictionary {dictionaryName}.");
+                    return null;
+                }
+                
+                return GetDictionaryFromFieldInfo<T>(field);
+            }
+            
+            Dictionary<string, T> GetDictionaryFromFieldInfo<T>(FieldInfo field)
             {
                 return (Dictionary<string, T>) field.GetValue(null);
             }
 
-            void AddDataSource<T>(string path, string dictionaryName)
+            void AddSimpleSource(string path, string postParseMethod)
             {
-                AddSource<T>(DataPath + path, dictionaryName);
+                AddSource<JsonSimple>(DataPath + path, "dictSimple", postParseMethod);
+            }
+
+            void AddDataSource<T>(string path, string dictionaryName, string postParseMethod = null)
+            {
+                AddSource<T>(DataPath + path, dictionaryName, postParseMethod);
             }
             
-            void AddSource<T>(string path, string dictionaryName)
+            void AddSource<T>(string path, string dictionaryName, string postParseMethod = null)
             {
                 Action<string, object> append = (k, o) => Append<T>(k, o, dictionaryName);
-                jsonPathToDataPath.Add(new JsonDataSource(path, typeof(T), append));
+
+                if (postParseMethod==null)
+                {
+                    postFixOnlyDataSource.Add(new SimplePostfixOnlyDataSource(path, typeof(T), append));
+                }
+                else
+                {
+                    postProcessedDataSources.Add(postParseMethod, new PostProcessedDataSource(path, typeof(T), append, postParseMethod));
+                }
             }
         }
-        
+
         private static Dictionary<string, FieldInfo> FindDictionaryFieldList()
         {
             var dictionaryField = new Dictionary<string, FieldInfo>();
@@ -142,7 +183,15 @@ namespace InteractionsPlus.JsonMerging
             return dictionaryField;
         }
 
-        public IEnumerator<JsonDataSource> GetEnumerator() => jsonPathToDataPath.GetEnumerator();
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        public IEnumerator EnumeratePostFixDataSources() => postFixOnlyDataSource.GetEnumerator();
+
+        public PostProcessedDataSource GetPostProcessedSourceFor(string postProcessMethodName)
+        {
+            if (postProcessedDataSources.TryGetValue(postProcessMethodName, out var source))
+            {
+                return source;
+            }
+            return null;
+        }
     }
 }

--- a/JsonMerging/JsonDataSourceCollection.cs
+++ b/JsonMerging/JsonDataSourceCollection.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal class JsonDataSourceCollection : IEnumerable<JsonDataSource>
+    {
+        private const string DataPath = "data/";
+        
+        [NotNull] private readonly ILogger logger;
+        [NotNull] private readonly List<JsonDataSource> jsonPathToDataPath = new List<JsonDataSource>();
+
+        public JsonDataSourceCollection([NotNull] ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public void InitializeDataSources()
+        {
+            var dictionaryFieldList = FindDictionaryFieldList();
+
+            AddDataSource<JsonColor>("colors.json","dictJsonColors");
+            AddDataSource<JsonLight>("lights.json","dictLights");
+            AddDataSource<JsonGasRespire>("gasrespires.json","dictGasRespires");
+            AddDataSource<JsonPowerInfo>("powerinfos.json","dictPowerInfo");
+            AddDataSource<JsonGUIPropMap>("guipropmaps.json","dictGUIPropMapUnparsed");
+            // DataHandler.ParseGUIPropMaps();
+            AddDataSource<JsonCond>("conditions.json","dictConds");
+            AddDataSource<JsonSimple>("conditions_simple.json","dictSimple");
+            // ParseConditionsSimple();
+            AddDataSource<JsonItemDef>("items.json", "dictItemDefs");
+            AddDataSource<CondTrigger>("condtrigs.json", "dictCTs");
+            AddDataSource<JsonInteraction>("interactions.json", "dictInteractions");
+            AddDataSource<JsonCondOwner>("condowners.json", "dictCOs");
+            //DataHandler.LoadShips();
+            AddDataSource<JsonCondOwner>("loot.json", "dictLoot");
+            //DataHandler.TxtToData(DataHandler.strAssetPath + DataHandler.strDataPath + "names_last.json", DataHandler.aNamesLast);
+            //DataHandler.dictSimple.Clear();
+            AddDataSource<JsonCondOwner>("names_first.json", "dictSimple");
+            //DataHandler.ParseFirstNames();
+            AddDataSource<JsonHomeworld>("homeworlds.json", "dictHomeworlds");
+            AddDataSource<JsonCareer>("careers.json", "dictCareers");
+            AddDataSource<JsonLifeEvent>("lifeevents.json", "dictLifeEvents");
+            AddDataSource<JsonPersonSpec>("personspecs.json", "dictPersonSpecs");
+            //DataHandler.dictSimple.Clear();
+            AddDataSource<JsonSimple>("traitscores.json", "dictSimple");
+            //DataHandler.ParseTraitScores();
+            //DataHandler.dictSimple.Clear();
+            AddDataSource<JsonSimple>( "strings.json","dictSimple");
+            //DataHandler.ParseGameStrings();
+            AddDataSource<JsonPlot>("plots.json", "dictPlots");
+            AddDataSource<JsonSlot>("slots.json", "dictSlots");
+            AddDataSource<JsonTicker>("tickers.json", "dictTickers");
+            AddDataSource<CondRule>("condrules.json", "dictCondRules");
+            AddDataSource<JsonAudioEmitter>( "audioemitters.json","dictAudioEmitters");
+            //DataHandler.dictSimple.Clear();
+            AddDataSource<JsonSimple>("crewskins.json", "dictSimple");
+            //DataHandler.ParseCrewSkins();
+            AddDataSource<JsonAd>("ads.json", "dictAds");
+            AddDataSource<JsonHeadline>("headlines.json", "dictHeadlines");
+            AddDataSource<JsonMusic>( "music.json", "dictMusic");
+            AddDataSource<JsonComputerEntry>("computerentries.json", "dictComputerEntries");
+            //DataHandler.ParseMusic();
+            AddDataSource<JsonCOOverlay>("cooverlays.json", "dictCOOverlays");
+            //DataHandler.dictSimple.Clear();
+            AddDataSource<JsonSimple>("names_ship.json", "dictSimple");
+            //DataHandler.ParseShipNames();
+            //DataHandler.dictSimple.Clear();
+            //DataHandler.ParseGeneratedShipNames();
+            AddDataSource<CondTrigger>("condtrigs2.json", "dictCTs");
+            AddDataSource<JsonInteraction>("interactions2.json", "dictSocials");
+            //DataHandler.dictSocialStats = new Dictionary<string, SocialStats>();
+            //foreach (JsonInteraction jsonInteraction in DataHandler.dictSocials.Values)
+            //{
+            //    DataHandler.dictInteractions[jsonInteraction.strName] = jsonInteraction;
+            //    DataHandler.dictSocialStats[jsonInteraction.strName] = new SocialStats(jsonInteraction.strName);
+            //}
+            //Dictionary<string, JsonInstallable> dict = new Dictionary<string, JsonInstallable>();
+            //DataHandler.JsonToData<JsonInstallable>(DataHandler.strAssetPath + DataHandler.strDataPath + "installables.json", dict);
+            //foreach (KeyValuePair<string, JsonInstallable> keyValuePair in dict)
+            //    Installables.Create(keyValuePair.Value);
+            //dict.Clear();
+            //if (File.Exists(Application.persistentDataPath + "/settings.json"))
+            //    DataHandler.JsonToData<JsonSetting>(Application.persistentDataPath + "/settings.json", DataHandler.dictSettings);
+            //DataHandler.bLoaded = true;
+            
+            
+            void Append<T>(string key, object typelessJson, string dictionaryName)
+            {
+                T typeJson = (T) typelessJson;
+
+                if (!dictionaryFieldList.TryGetValue(dictionaryName, out FieldInfo field))
+                {
+                    return;
+                }
+                
+                Dictionary<string, T> dictionary = GetDictionary<T>(field);
+                if (dictionary.ContainsKey(key))
+                {
+                    logger.Error($"Cannot append {key}. Key already exists.");
+                    return;
+                }
+                logger.Log($"Data {key} appended");
+                
+                dictionary.Add(key, typeJson);
+            }
+
+            Dictionary<string, T> GetDictionary<T>(FieldInfo field)
+            {
+                return (Dictionary<string, T>) field.GetValue(null);
+            }
+
+            void AddDataSource<T>(string path, string dictionaryName)
+            {
+                AddSource<T>(DataPath + path, dictionaryName);
+            }
+            
+            void AddSource<T>(string path, string dictionaryName)
+            {
+                Action<string, object> append = (k, o) => Append<T>(k, o, dictionaryName);
+                jsonPathToDataPath.Add(new JsonDataSource(path, typeof(T), append));
+            }
+        }
+        
+        private static Dictionary<string, FieldInfo> FindDictionaryFieldList()
+        {
+            var dictionaryField = new Dictionary<string, FieldInfo>();
+            var fieldList = typeof(DataHandler).GetFields();
+            foreach (FieldInfo field in fieldList)
+            {
+                if (!typeof(IDictionary).IsAssignableFrom(field.FieldType))
+                {
+                    continue;
+                }
+
+                dictionaryField.Add(field.Name, field);
+            }
+
+            return dictionaryField;
+        }
+
+        public IEnumerator<JsonDataSource> GetEnumerator() => jsonPathToDataPath.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/JsonMerging/JsonParsingUtils.cs
+++ b/JsonMerging/JsonParsingUtils.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using InteractionsPlus.JetBrains.Annotations;
+using LitJson;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal class JsonParsingUtils
+    {
+        public delegate void ParseAndAppendDelegate(string modPath, string jsonPath, object untypedDictionary);
+
+        private static ILogger logger;
+        [NotNull]
+        public static ParseAndAppendDelegate CreateParseDelegate(Type jsonObjectType)
+        {
+            InteractionsPlusMod.Services.TryResolve(out logger);
+            
+            Type utilType = typeof(JsonParsingUtils);
+            MethodInfo methodInfo = utilType.GetMethod(nameof(ParseAndAppendJsonData));
+            
+            if (methodInfo == null)
+            {
+                throw new Exception($"Cannot resolve {nameof(ParseAndAppendJsonData)}");
+            }
+            
+            var typedMethod = methodInfo.MakeGenericMethod(jsonObjectType);
+
+            return (ParseAndAppendDelegate) Delegate.CreateDelegate(typeof(ParseAndAppendDelegate), typedMethod);
+        }
+
+        public static void ParseAndAppendJsonData<TJson>([NotNull] string modPath, [NotNull] string jsonPath, object dictionary)
+        {
+            var typedDictionary = (Dictionary<string, TJson>) dictionary;
+
+            ParseAdditionalJsonInPath<TJson>(modPath, jsonPath,
+                (key, parsed) => AppendAdditionalJsonDataToDictionary(typedDictionary, key, parsed, jsonPath));
+        }
+        
+        private static void AppendAdditionalJsonDataToDictionary<TJson>([NotNull]Dictionary<string, TJson> dictionary,
+            [NotNull]string key, [NotNull]TJson parsedJson, [NotNull]string jsonPath)
+        {
+            if (dictionary.ContainsKey(key))
+            {
+                logger?.Error($"Cannot append {key} to {jsonPath}");
+                return;
+            }
+            logger?.Log($"Data {key} appended to {jsonPath}");
+            dictionary.Add(key, parsedJson);
+        }
+
+        public static void ParseAdditionalJsonInPath<TJson>([NotNull] string modPath, [NotNull] string jsonPath,
+            [NotNull] Action<string, TJson> appendDelegate)
+        {
+            var additionalJsonPath = Path.Combine(modPath, jsonPath);
+            // logger?.Log($"Modpath {modPath} jsonPath{jsonPath} merged {additionalJsonPath}");
+            if (!File.Exists(additionalJsonPath))
+            {
+                return;
+            }
+            
+            string jsonString = File.ReadAllText(additionalJsonPath, Encoding.UTF8);
+            JsonData jsonArray = JsonMapper.ToObject(jsonString);
+            if (jsonArray == null || !jsonArray.IsArray)
+            {
+                return;
+            }
+            
+            foreach (JsonData parsedJsonData in jsonArray)
+            {
+                if (parsedJsonData == null || parsedJsonData["strName"] == null)
+                {
+                    continue;
+                }
+                
+                var key = parsedJsonData["strName"].ToString();
+                appendDelegate(key, JsonMapper.ToObject<TJson>(parsedJsonData.ToJson()));
+            }
+        }
+    }
+}

--- a/JsonMerging/JsonParsingUtils.cs
+++ b/JsonMerging/JsonParsingUtils.cs
@@ -87,6 +87,8 @@ namespace InteractionsPlus.JsonMerging
         [NotNull]
         public static ParseAndAppendUntypedDelegate GetParseAdditionalJsonInPathAndAppendTypeless([NotNull] Type jsonType)
         {
+            InteractionsPlusMod.Services.TryResolve(out logger);
+            
             if (cachedDelegates.TryGetValue(jsonType, out var existing))
             {
                 return existing;
@@ -105,10 +107,12 @@ namespace InteractionsPlus.JsonMerging
         public static void ParseAdditionalJsonInPathAndAppendTypeless<TJson>([NotNull] string modPath, [NotNull] string jsonPath,
             [NotNull] Action<string, object> appendDelegate)
         {
+            InteractionsPlusMod.Services.TryResolve(out logger);
             var additionalJsonPath = Path.Combine(modPath, jsonPath);
-            // logger?.Log($"Modpath {modPath} jsonPath{jsonPath} merged {additionalJsonPath}");
+            //logger?.Log($"Modpath {modPath} jsonPath{jsonPath} merged {additionalJsonPath}");
             if (!File.Exists(additionalJsonPath))
             {
+                //logger?.Error($"Missing file {additionalJsonPath}");
                 return;
             }
             
@@ -116,6 +120,7 @@ namespace InteractionsPlus.JsonMerging
             JsonData jsonArray = JsonMapper.ToObject(jsonString);
             if (jsonArray == null || !jsonArray.IsArray)
             {
+                logger?.Error($"Not an json array {additionalJsonPath}");
                 return;
             }
             
@@ -123,10 +128,12 @@ namespace InteractionsPlus.JsonMerging
             {
                 if (parsedJsonData == null || parsedJsonData["strName"] == null)
                 {
+                    logger?.Error($"Empty or no strName");
                     continue;
                 }
                 
                 var key = parsedJsonData["strName"].ToString();
+                logger?.Log($"Add data {key}");
                 appendDelegate(key, JsonMapper.ToObject<TJson>(parsedJsonData.ToJson()));
             }
         }

--- a/JsonMerging/JsonParsingUtils.cs
+++ b/JsonMerging/JsonParsingUtils.cs
@@ -115,9 +115,20 @@ namespace InteractionsPlus.JsonMerging
                 //logger?.Error($"Missing file {additionalJsonPath}");
                 return;
             }
+
+            JsonData jsonArray = null;
+            try
+            {
+                string jsonString = File.ReadAllText(additionalJsonPath, Encoding.UTF8);
+                jsonArray = JsonMapper.ToObject(jsonString);
+            }
+            catch (Exception e)
+            {
+                logger?.Error($"Cannot parse invalid json format {additionalJsonPath}");
+                logger?.LogException(e);
+                return;
+            }
             
-            string jsonString = File.ReadAllText(additionalJsonPath, Encoding.UTF8);
-            JsonData jsonArray = JsonMapper.ToObject(jsonString);
             if (jsonArray == null || !jsonArray.IsArray)
             {
                 logger?.Error($"Not an json array {additionalJsonPath}");

--- a/JsonMerging/MergedJsonDataManager.cs
+++ b/JsonMerging/MergedJsonDataManager.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using JetBrains.Annotations;
+using LitJson;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal class MergedJsonDataManager
+    {
+        private bool initialized;
+     
+        [NotNull] private readonly ILogger logger;
+        [NotNull] private readonly JsonDataSourceCollection jsonDataSourceCollection;
+
+        public MergedJsonDataManager([NotNull] ILogger logger)
+        {
+            this.logger = logger;
+            jsonDataSourceCollection = new JsonDataSourceCollection(logger);
+        }
+        
+        public void Initialized()
+        {
+            if (initialized)
+            {
+                return;
+            }
+
+            initialized = true;
+            jsonDataSourceCollection.InitializeDataSources();
+        }
+        
+        public void LoadJsonData(string modPath)
+        {
+            foreach (JsonDataSource dataSource in jsonDataSourceCollection)
+            {
+                ParseDataSource(modPath, dataSource);
+            }
+        }
+        
+        private void ParseDataSource(string modPath, JsonDataSource dataSource)
+        {
+            var jsonPath = dataSource.Path;
+            
+            logger.Log($"Parsing additional json {modPath} {jsonPath} {dataSource.AppendAction!=null}");
+
+            var appendMethod = typeof(MergedJsonDataManager).GetMethod(nameof(ParseAdditionalJsonInPath));
+            appendMethod.MakeGenericMethod(dataSource.JsonType)
+                .Invoke(null, new object[] {modPath,  dataSource.Path, dataSource.AppendAction});
+        }
+        
+        public static void ParseAdditionalJsonInPath<TJson>([NotNull] string modPath, [NotNull] string jsonPath,
+            [NotNull] Action<string, object> appendDelegate)
+        {
+            var additionalJsonPath = Path.Combine(modPath, jsonPath);
+            // logger?.Log($"Modpath {modPath} jsonPath{jsonPath} merged {additionalJsonPath}");
+            if (!File.Exists(additionalJsonPath))
+            {
+                return;
+            }
+            
+            string jsonString = File.ReadAllText(additionalJsonPath, Encoding.UTF8);
+            JsonData jsonArray = JsonMapper.ToObject(jsonString);
+            if (jsonArray == null || !jsonArray.IsArray)
+            {
+                return;
+            }
+            
+            foreach (JsonData parsedJsonData in jsonArray)
+            {
+                if (parsedJsonData == null || parsedJsonData["strName"] == null)
+                {
+                    continue;
+                }
+                
+                var key = parsedJsonData["strName"].ToString();
+                appendDelegate(key, JsonMapper.ToObject<TJson>(parsedJsonData.ToJson()));
+            }
+        }
+    }
+}

--- a/JsonMerging/MergedJsonDataManager.cs
+++ b/JsonMerging/MergedJsonDataManager.cs
@@ -34,48 +34,10 @@ namespace InteractionsPlus.JsonMerging
         {
             foreach (JsonDataSource dataSource in jsonDataSourceCollection)
             {
-                ParseDataSource(modPath, dataSource);
+                dataSource.ParseModPath(modPath);
             }
         }
         
-        private void ParseDataSource(string modPath, JsonDataSource dataSource)
-        {
-            var jsonPath = dataSource.Path;
-            
-            logger.Log($"Parsing additional json {modPath} {jsonPath} {dataSource.AppendAction!=null}");
-
-            var appendMethod = typeof(MergedJsonDataManager).GetMethod(nameof(ParseAdditionalJsonInPath));
-            appendMethod.MakeGenericMethod(dataSource.JsonType)
-                .Invoke(null, new object[] {modPath,  dataSource.Path, dataSource.AppendAction});
-        }
         
-        public static void ParseAdditionalJsonInPath<TJson>([NotNull] string modPath, [NotNull] string jsonPath,
-            [NotNull] Action<string, object> appendDelegate)
-        {
-            var additionalJsonPath = Path.Combine(modPath, jsonPath);
-            // logger?.Log($"Modpath {modPath} jsonPath{jsonPath} merged {additionalJsonPath}");
-            if (!File.Exists(additionalJsonPath))
-            {
-                return;
-            }
-            
-            string jsonString = File.ReadAllText(additionalJsonPath, Encoding.UTF8);
-            JsonData jsonArray = JsonMapper.ToObject(jsonString);
-            if (jsonArray == null || !jsonArray.IsArray)
-            {
-                return;
-            }
-            
-            foreach (JsonData parsedJsonData in jsonArray)
-            {
-                if (parsedJsonData == null || parsedJsonData["strName"] == null)
-                {
-                    continue;
-                }
-                
-                var key = parsedJsonData["strName"].ToString();
-                appendDelegate(key, JsonMapper.ToObject<TJson>(parsedJsonData.ToJson()));
-            }
-        }
     }
 }

--- a/JsonMerging/MergedJsonDataManager.cs
+++ b/JsonMerging/MergedJsonDataManager.cs
@@ -30,12 +30,21 @@ namespace InteractionsPlus.JsonMerging
             jsonDataSourceCollection.InitializeDataSources();
         }
         
-        public void LoadJsonData(string modPath)
+        public void LoadPostFixJsonData(string modPath)
         {
-            foreach (JsonDataSource dataSource in jsonDataSourceCollection)
+            logger.Log($"Loading data for mod {modPath}");
+            var enumerable = jsonDataSourceCollection.EnumeratePostFixDataSources();
+            while (enumerable.MoveNext())
             {
+                JsonDataSource dataSource = (JsonDataSource)enumerable.Current;
                 dataSource.ParseModPath(modPath);
             }
+        }
+
+        public void LoadPostProcessing(string modPath, string postProcessMethodName)
+        {
+            PostProcessedDataSource source = jsonDataSourceCollection.GetPostProcessedSourceFor(postProcessMethodName);
+            source.ParseModPath(modPath);
         }
         
         

--- a/JsonMerging/PostProcessedDataSource.cs
+++ b/JsonMerging/PostProcessedDataSource.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal class PostProcessedDataSource : SimplePostfixOnlyDataSource
+    {
+        public readonly string PostProcessMethodName;
+
+        public PostProcessedDataSource(string path, Type type, Action<string, object> appendAction, string postProcessMethodName) : base(path, type, appendAction)
+        {
+            PostProcessMethodName = postProcessMethodName;
+        }
+    }
+}

--- a/JsonMerging/SimplePostfixOnlyDataSource.cs
+++ b/JsonMerging/SimplePostfixOnlyDataSource.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal class SimplePostfixOnlyDataSource : JsonDataSource
+    {
+        public SimplePostfixOnlyDataSource(string path, Type type, Action<string, object> appendAction)
+            : base(path, type, appendAction)
+        {
+        }
+
+        protected override void ParseDataSource(string modPath)
+        {
+            var jsonPath = Path;
+            var parseDelegate = JsonParsingUtils.GetParseAdditionalJsonInPathAndAppendTypeless(JsonType);
+            parseDelegate(modPath,  jsonPath, AppendAction);
+        }
+    }
+}

--- a/ModDependency/UMMDependencyManager.cs
+++ b/ModDependency/UMMDependencyManager.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using JetBrains.Annotations;
+using UnityModManagerNet;
+
+namespace InteractionsPlus.ModDependency
+{
+    public class UMMDependencyManager
+    {
+        [NotNull] private readonly ILogger logger;
+
+        private List<UnityModManager.ModEntry> modEntries;
+        
+        internal UMMDependencyManager([NotNull] ILogger logger)
+        {
+            this.logger = logger;
+        }
+        
+        internal void SetModList(List<UnityModManager.ModEntry> modEntries)
+        {
+            this.modEntries = modEntries;
+        }
+
+        [NotNull]
+        public List<string> GetDependentModPaths(bool enabledOnly = true)
+        {
+            var pathList = new List<string>();
+            if (modEntries == null)
+            {
+                return pathList;
+            }
+            
+            foreach (var entry in modEntries)
+            {
+                if (
+                    !RequiresInteractionsPlus(entry)
+                    || (enabledOnly && !entry.Enabled)
+                )
+                {
+                    continue;
+                }
+                pathList.Add(entry.Path);
+            }
+            return pathList;
+        }
+
+        private bool RequiresInteractionsPlus(UnityModManager.ModEntry entry)
+        {
+            return entry.Requirements.ContainsKey(InteractionsPlusMod.ModId);
+        }
+    }
+}

--- a/Patchers/DataHandlerAdditionalJsonPatcher.cs
+++ b/Patchers/DataHandlerAdditionalJsonPatcher.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using HarmonyLib;
+using InteractionsPlus.JsonMerging;
+using InteractionsPlus.ModDependency;
+
+namespace InteractionsPlus.Patchers
+{
+    [HarmonyPatch(typeof(DataHandler))]
+    public class DataHandlerAdditionalJsonPatcher
+    {
+        
+        private static ILogger logger;
+        
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(DataHandler.Init))]
+        static void ConstructorPostfix()
+        {
+            InteractionsPlusMod.Services.TryResolve(out logger);
+            
+            if (!InteractionsPlusMod.Services.TryResolve(out UMMDependencyManager dependencyManager)||dependencyManager==null ||
+                !InteractionsPlusMod.Services.TryResolve(out MergedJsonDataManager jsonDataCache)|| jsonDataCache==null )
+            {
+                return;
+            }
+            
+            jsonDataCache.Initialized();
+            
+            List<string> modPathList = dependencyManager.GetDependentModPaths(true);
+            foreach (string modPath in modPathList)
+            {
+                jsonDataCache.LoadJsonData(modPath);
+            }
+        }
+    }
+}

--- a/Patchers/DataHandlerInitPostfixPatcher.cs
+++ b/Patchers/DataHandlerInitPostfixPatcher.cs
@@ -6,9 +6,8 @@ using InteractionsPlus.ModDependency;
 namespace InteractionsPlus.Patchers
 {
     [HarmonyPatch(typeof(DataHandler))]
-    public class DataHandlerAdditionalJsonPatcher
+    public class DataHandlerInitPostfixPatcher
     {
-        
         private static ILogger logger;
         
         [HarmonyPostfix]
@@ -28,7 +27,7 @@ namespace InteractionsPlus.Patchers
             List<string> modPathList = dependencyManager.GetDependentModPaths(true);
             foreach (string modPath in modPathList)
             {
-                jsonDataCache.LoadJsonData(modPath);
+                jsonDataCache.LoadPostFixJsonData(modPath);
             }
         }
     }

--- a/Patchers/DataHandlerPostprocessedPrefixPatcher.cs
+++ b/Patchers/DataHandlerPostprocessedPrefixPatcher.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using InteractionsPlus.JsonMerging;
+using InteractionsPlus.ModDependency;
+using UnityEngine;
+
+namespace InteractionsPlus.Patchers
+{
+    [HarmonyPatch]
+    public class DataHandlerPostprocessedPrefixPatcher
+    {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            InteractionsPlusMod.Services.TryResolve(out logger);
+            var handlerType = typeof(DataHandler);
+
+            HashSet<string> foundMethods = new HashSet<string>();
+            string[] targetMethodNames = new []
+                {
+                    "ParseGUIPropMaps",
+                    "ParseConditionsSimple",
+                    "ParseFirstNames",
+                    "ParseTraitScores",
+                    "ParseGameStrings",
+                    "ParseCrewSkins",
+                    "ParseMusic",
+                    "ParseShipNames"
+                };
+
+            foreach (MethodInfo methodBase in handlerType.GetMethods(BindingFlags.NonPublic|BindingFlags.Static))
+            {
+                string methodName = methodBase.Name;
+                if (!targetMethodNames.Contains(methodName))
+                {
+                    continue;
+                }
+                foundMethods.Add(methodName);
+                yield return methodBase;
+            }
+
+            foreach (string targetMethodName in targetMethodNames)
+            {
+                if (!foundMethods.Contains(targetMethodName))
+                {
+                    logger?.Error($"Could not find {targetMethodName} to patch");
+                }
+            }
+        }
+        
+        private static ILogger logger;
+        
+        static void Prefix(MethodBase __originalMethod)
+        {
+            InteractionsPlusMod.Services.TryResolve(out logger);
+            
+            if (!InteractionsPlusMod.Services.TryResolve(out UMMDependencyManager dependencyManager)||dependencyManager==null ||
+                !InteractionsPlusMod.Services.TryResolve(out MergedJsonDataManager jsonDataCache)|| jsonDataCache==null )
+            {
+                return;
+            }
+
+            Quaternion.LookRotation(Vector3.forward, Vector3.up);
+            
+            jsonDataCache.Initialized();
+            string methodName = __originalMethod.Name;
+            
+            List<string> modPathList = dependencyManager.GetDependentModPaths(true);
+            foreach (string modPath in modPathList)
+            {
+                jsonDataCache.LoadPostProcessing(modPath, methodName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added merging support for json files under **_"StreamingAssets/data"_** folder. In order to use this feature, a third party mod needs to be configured as an UMM mod and set InteractionsPlus as an requirement in the mod's **_"Info.json"_** file.

Basic support currently loads all UMM mods regardless of their enabled/disabled state. The reason is that the game does parse, files at the startup, not before the game session starts. Other possibilities may be investigated in the future to support toggling mods. 

At this point if a save file includes a modded item and the mod is not loaded the UI cannot load that save file.

The loaded data files are manually entered in code. In a previous attempt, patching generic method that parses the data proved impossible. Harmony can parch generic methods, however doing so loses the original generic values. As such referenced dictionary is null or empty. This can also be investigated in future.