### PR TITLE
Merging Support for Existing Json Objects in Data

### DIFF
--- a/Exceptions/JsonFormatException.cs
+++ b/Exceptions/JsonFormatException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace InteractionsPlus.Exceptions
+{
+    public class JsonFormatException : Exception
+    {
+        public JsonFormatException(Exception innerException, string key, Type jsonType):base(CreateMessage(key, jsonType), innerException)
+        {
+        }
+
+        private static string CreateMessage(string key, Type jsonType)
+        {
+            return $"Cannot convert {key} to expected type {jsonType.Name}";
+        }
+
+        public override string ToString()
+        {
+            var message = base.ToString();
+            message += "\n === Inner Exception === \n";
+            message += InnerException.ToString();
+            return message;
+        }
+    }
+}

--- a/JsonMerging/DataHandlerDictionaryAccessor.cs
+++ b/JsonMerging/DataHandlerDictionaryAccessor.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal class DataHandlerDictionaryAccessor
+    {
+        private readonly ILogger logger;
+
+        [NotNull]
+        private readonly Dictionary<string, FieldInfo> fieldInfos;
+
+        public DataHandlerDictionaryAccessor(ILogger logger)
+        {
+            this.logger = logger;
+            fieldInfos = FindDictionaryFieldList();
+        }
+        
+        public Dictionary<string, T> GetDictionary<T>([NotNull] string dictionaryName)
+        {
+            if (!fieldInfos.TryGetValue(dictionaryName, out FieldInfo field))
+            {
+                logger.Error($"Cannot find data dictionary {dictionaryName}.");
+                return null;
+            }
+                
+            return GetDictionaryFromFieldInfo<T>(field);
+        }
+
+        [NotNull]
+        private static Dictionary<string, FieldInfo> FindDictionaryFieldList()
+        {
+            var dictionaryField = new Dictionary<string, FieldInfo>();
+            var fieldList = typeof(DataHandler).GetFields();
+            foreach (FieldInfo field in fieldList)
+            {
+                if (!typeof(IDictionary).IsAssignableFrom(field.FieldType))
+                {
+                    continue;
+                }
+
+                dictionaryField.Add(field.Name, field);
+            }
+
+            return dictionaryField;
+        }
+        
+        private Dictionary<string, T> GetDictionaryFromFieldInfo<T>([NotNull] FieldInfo field)
+        {
+            return (Dictionary<string, T>) field.GetValue(null);
+        }
+
+    }
+}

--- a/JsonMerging/DataHandlerDictionarySource.cs
+++ b/JsonMerging/DataHandlerDictionarySource.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using InteractionsPlus.JetBrains.Annotations;
+using LitJson;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal abstract class DataHandlerDictionarySource<TJson> : JsonDataSource<TJson> 
+    {
+        [NotNull] protected readonly string DictionaryName;
+        [NotNull] protected readonly DataHandlerDictionaryAccessor Accessor;
+
+        public DataHandlerDictionarySource([NotNull] ILogger logger, [NotNull] string path,
+            [NotNull] String dictionaryName, [NotNull] DataHandlerDictionaryAccessor accessor) 
+            : base(logger, path)
+        {
+            DictionaryName = dictionaryName;
+            Accessor = accessor;
+        }
+        
+        protected override void ParseDataSource(string modPath)
+        {
+            var jsonPath = Path;
+
+            if (!JsonParsingUtils.TryParseAdditionalJsonArrayInPath(modPath, jsonPath, out JsonData jsonArray))
+            {
+                return;
+            }
+            
+            // Access dictionary just in time to avoid fetching null or old dictionary.
+            Dictionary<string, TJson> dictionary = Accessor.GetDictionary<TJson>(DictionaryName);
+            Appender.ProcessJsonArray(dictionary, jsonArray);
+        }
+    }
+}

--- a/JsonMerging/JsonAppender.cs
+++ b/JsonMerging/JsonAppender.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using LitJson;
+using TinyJson;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal class JsonAppender<TJson>
+    {
+        public delegate void ItemParsedHandler(ItemProcessedArgs itemProcessedArgs);
+
+        public event ItemParsedHandler ItemParsed;
+        
+        [NotNull]
+        private readonly ILogger logger;
+
+        public JsonAppender([NotNull] ILogger logger)
+        {
+            this.logger = logger;
+        }
+        
+        public void ProcessJsonArray([NotNull] Dictionary<string,TJson> targetDictionary, [NotNull] JsonData jsonArray)
+        {
+            int emptyItemFound = 0;
+            foreach (JsonData objectJsonData in jsonArray)
+            {
+                ProcessItem(targetDictionary, objectJsonData, ref emptyItemFound);
+            }
+
+            if (emptyItemFound != 0)
+            {
+                logger.Error($"{emptyItemFound} items found empty or with no strName assigned");
+            }
+        }
+
+        private void ProcessItem([NotNull] Dictionary<string, TJson> targetDictionary, JsonData objectJsonData, ref int emptyItemFound)
+        {
+            if (objectJsonData?["strName"] == null)
+            {
+                emptyItemFound++;
+                return;
+            }
+
+            var key = objectJsonData["strName"].ToString();
+
+            if (targetDictionary.ContainsKey(key))
+            {
+                ApplyItemOverrides(targetDictionary, objectJsonData, key);
+            }
+            else
+            {
+                AppendItem(targetDictionary, objectJsonData, key);
+            }
+        }
+
+        private void ApplyItemOverrides([NotNull] Dictionary<string, TJson> targetDictionary,
+            [NotNull] JsonData objectJsonData, [NotNull] string key)
+        {
+            logger.Log($"Checking for override {key}");
+
+            Dictionary<string, string> overrideStrategies = MakeOverrideKeyToStrategyMap(objectJsonData);
+            if (overrideStrategies.Count == 0)
+            {
+                logger.Log("Cannot find valid override. Skipping.");
+                return;
+            }
+
+            TJson original = targetDictionary[key];
+            JsonData originalAsData = JsonMapper.ToObject(original.ToJson());
+            
+            foreach (KeyValuePair<string, string> kvp in overrideStrategies)
+            {
+                var overrideKey = kvp.Key;
+                var strategy = kvp.Value;
+                
+                if (overrideKey == null || strategy == null)
+                {
+                    continue;
+                }
+                
+                ApplyOverrideStrategy(originalAsData, objectJsonData, overrideKey, strategy);
+            }
+            
+            if (TryConvertToTypedJson(originalAsData, key, out TJson overriden))
+            {
+                targetDictionary[key] = overriden;
+            }
+        }
+
+        private void ApplyOverrideStrategy([NotNull] JsonData originalAsData, [NotNull] JsonData overrideData,
+            [NotNull] string overrideKey, [NotNull] string strategy)
+        {
+            var jsonToSource = overrideData[overrideKey];
+            var jsonToTarget = originalAsData[overrideKey];
+            if (jsonToTarget == null || jsonToSource == null)
+            {
+                return;
+            }
+
+            if (strategy == "append")
+            {
+                ApplyAppendOverride(jsonToSource, jsonToTarget, overrideKey);
+            }
+            else if (strategy == "overwrite")
+            {
+                ApplyOverwriteOverride(jsonToSource, jsonToTarget, overrideKey);
+            }
+            else if (strategy == "remove")
+            {
+                ApplyRemoveOverride(jsonToSource, jsonToTarget, overrideKey);
+            }
+        }
+        
+        private void ApplyAppendOverride([NotNull] JsonData jsonToSource, [NotNull] JsonData jsonToTarget, string debugKey)
+        {
+            if (!jsonToSource.IsArray || !jsonToTarget.IsArray)
+            {
+                logger.Log($"Cannot append {debugKey}. Not a valid array json");
+                return;
+            }
+
+            int count = 0;
+            foreach (JsonData data in jsonToSource)
+            {
+                jsonToTarget.Add(data);
+                count++;
+            }
+            logger.Log($"Appended {count} items to {debugKey}.");
+        }
+        
+        private void ApplyOverwriteOverride([NotNull] JsonData jsonToSource, [NotNull] JsonData jsonToTarget, string debugKey)
+        {
+            if (!jsonToSource.IsArray || !jsonToTarget.IsArray)
+            {
+                logger.Log($"Cannot append {debugKey}. Not a valid array json");
+                return;
+            }
+         
+            jsonToTarget.Clear();
+            int count = 0;
+            foreach (JsonData data in jsonToSource)
+            {
+                jsonToTarget.Add(data);
+                count++;
+            }
+            logger.Log($"Overwritten with {count} items to {debugKey}.");
+        }
+        
+        private void ApplyRemoveOverride([NotNull] JsonData jsonToSource, [NotNull] JsonData jsonToTarget, string debugKey)
+        {
+            if (!jsonToSource.IsArray || !jsonToTarget.IsArray)
+            {
+                logger.Log($"Cannot append {debugKey}. Not a valid array json");
+                return;
+            }
+            
+            HashSet<string> dataToKeep = new HashSet<string>();
+            foreach (JsonData existingData in jsonToTarget)
+            {
+                dataToKeep.Add(existingData.ToJson());
+            }
+
+            int count = 0;
+            foreach (JsonData toRemoveData in jsonToSource)
+            {
+                dataToKeep.Remove(toRemoveData.ToJson());
+                count++;
+            }
+
+            jsonToTarget.Clear();
+
+            foreach (string jsonStr in dataToKeep)
+            {
+                jsonToTarget.Add(JsonMapper.ToObject(jsonStr));
+            }
+            logger.Log($"Removed {count} items from {debugKey}.");
+        }
+
+        [NotNull]
+        private Dictionary<string,string> MakeOverrideKeyToStrategyMap([NotNull] JsonData jsonData)
+        {
+            const string overrideKeyword = ".override";
+            var dictionary = new Dictionary<string, string>();
+            var keys = jsonData.Keys;
+            if (keys == null)
+            {
+                logger.Error("JsonData is missing keys");
+                return dictionary;
+            }
+            
+            foreach (string propertyKey in keys)
+            {
+                AddOverrideStrategyForProperty(propertyKey);
+            }
+            return dictionary;
+
+            void AddOverrideStrategyForProperty(string propertyKey)
+            {
+                if (propertyKey == null || !propertyKey.EndsWith(overrideKeyword))
+                {
+                    return;
+                }
+
+                JsonData strategyData = jsonData[propertyKey];
+                string overrideStrategy = (strategyData != null) ? strategyData.ToString() : "overwrite";
+                string overriddenKey = propertyKey.Substring(0, propertyKey.Length - overrideKeyword.Length);
+                dictionary.Add(overriddenKey, overrideStrategy);
+            }
+        }
+
+        private void AppendItem([NotNull] Dictionary<string, TJson> targetDictionary, [NotNull] JsonData parsedJsonData, [NotNull] string key)
+        {
+            logger.Log($"Appending {key}");
+
+            if (!TryConvertToTypedJson(parsedJsonData, key, out TJson json) || json == null)
+            {
+                return;
+            }
+            
+            targetDictionary.Add(key, json);
+            ItemParsed?.Invoke(new ItemProcessedArgs(key, json, isNewObject: true));
+        }
+
+        private bool TryConvertToTypedJson([NotNull] JsonData parsedJsonData, [NotNull] string key, out TJson json)
+        {
+            try
+            {
+                json = JsonParsingUtils.ConvertToTypedJson<TJson>(parsedJsonData, key);
+                return true;
+            }
+            catch (Exception e)
+            {
+                logger.LogException(e);
+                json = default(TJson);
+                return false;
+            }
+        }
+
+        public struct ItemProcessedArgs
+        {
+            [NotNull] public readonly string Key;
+            [NotNull] public readonly TJson ParsedObject;
+            public readonly bool IsNewObject;
+            public ItemProcessedArgs([NotNull] string key, [NotNull] TJson parsedObject, bool isNewObject)
+            {
+                Key = key;
+                ParsedObject = parsedObject;
+                IsNewObject = isNewObject;
+            }
+        }
+    }
+}

--- a/JsonMerging/JsonDataSource.cs
+++ b/JsonMerging/JsonDataSource.cs
@@ -1,25 +1,53 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace InteractionsPlus.JsonMerging
 {
-    internal abstract class JsonDataSource
+    internal interface JsonDataSource
     {
-        public readonly string Path;
-        public readonly Type JsonType;
-        public readonly Action<string, object> AppendAction;
-            
-        public JsonDataSource(string path, Type type, Action<string,object> appendAction)
+        void ParseModPath(string modPath);
+    }
+    
+    internal abstract class JsonDataSource<TJson> : JsonDataSource
+    {
+        [NotNull] public readonly string Path;
+        [NotNull] public readonly Type JsonType;
+        [NotNull] protected readonly JsonAppender<TJson> Appender;
+
+        public event Action<TJson> ItemProcessed; 
+        public event Action<TJson> ItemAppended;
+        public event Action<TJson> ItemModified;
+
+        public JsonDataSource([NotNull] ILogger logger,  [NotNull] string path)
         {
             Path = path;
-            JsonType = type;
-            AppendAction = appendAction;
+            JsonType = typeof(TJson);
+            
+            Appender = new JsonAppender<TJson>(logger);
+            Appender.ItemParsed += OnItemProcess;
+            ItemAppended += ItemProcessed;
+            ItemModified += ItemProcessed;
         }
 
-        public void ParseModPath(string modPath)
+        public void ParseModPath([NotNull]string modPath)
         {
             ParseDataSource(modPath);
         }
+        protected abstract void ParseDataSource([NotNull]string modPath);
+        
+        protected virtual void OnItemProcess(JsonAppender<TJson>.ItemProcessedArgs itemProcessedArgs)
+        {
+            if (itemProcessedArgs.IsNewObject)
+            {
+                DispatchAppendedEvent(itemProcessedArgs.ParsedObject);
+            }
+            else
+            {
+                DispatchModifiedEvent(itemProcessedArgs.ParsedObject);
+            }
+        }
 
-        protected abstract void ParseDataSource(string modPath);
+        protected void DispatchAppendedEvent(TJson parsedObject) => ItemAppended?.Invoke(parsedObject);
+        protected void DispatchModifiedEvent(TJson parsedObject) => ItemModified?.Invoke(parsedObject);
     }
 }

--- a/JsonMerging/JsonDataSourceCollection.cs
+++ b/JsonMerging/JsonDataSourceCollection.cs
@@ -37,7 +37,7 @@ namespace InteractionsPlus.JsonMerging
             
             //DataHandler.LoadShips(); // Multi json source
 
-            AddDataSource<JsonCondOwner>("loot.json", "dictLoot");
+            AddDataSource<Loot>("loot.json", "dictLoot");
             //DataHandler.TxtToData(DataHandler.strAssetPath + DataHandler.strDataPath + "names_last.json", DataHandler.aNamesLast);
             //DataHandler.dictSimple.Clear();
             AddSimpleSource("names_first.json", "ParseFirstNames");

--- a/JsonMerging/JsonParsingUtils.cs
+++ b/JsonMerging/JsonParsingUtils.cs
@@ -108,7 +108,7 @@ namespace InteractionsPlus.JsonMerging
         public static void ParseAdditionalJsonInPathAndAppendTypeless<TJson>([NotNull] string modPath, [NotNull] string jsonPath,
             [NotNull] Action<string, object> appendDelegate)
         {
-            if (!TryParseAdditionalJsonInPath(modPath, jsonPath, out JsonData jsonArray) || jsonArray == null)
+            if (!TryParseAdditionalJsonArrayInPath(modPath, jsonPath, out JsonData jsonArray) || jsonArray == null)
             {
                 return;
             }
@@ -124,7 +124,7 @@ namespace InteractionsPlus.JsonMerging
             }
         }
 
-        public static bool TryParseAdditionalJsonInPath([NotNull] string modPath, [NotNull] string jsonPath, out JsonData jsonArray)
+        public static bool TryParseAdditionalJsonArrayInPath([NotNull] string modPath, [NotNull] string jsonPath, out JsonData jsonArray)
         {
             InteractionsPlusMod.Services.TryResolve(out logger);
             var additionalJsonPath = Path.Combine(modPath, jsonPath);
@@ -168,16 +168,18 @@ namespace InteractionsPlus.JsonMerging
         private static void ConvertToTypedJsonAndAppend<TJson>(Action<string, object> appendDelegate, JsonData parsedJsonData)
         {
             var key = parsedJsonData["strName"].ToString();
+            
+        }
 
-            TJson typedJson;
+        public static TJson ConvertToTypedJson<TJson>([NotNull] JsonData parsedJsonData, string debugKey = null)
+        {
             try
             {
-                typedJson = JsonMapper.ToObject<TJson>(parsedJsonData.ToJson());
-                appendDelegate(key, typedJson);
+                return JsonMapper.ToObject<TJson>(parsedJsonData.ToJson());
             }
             catch (Exception e)
             {
-                var richException = new JsonFormatException(e, key, typeof(TJson));
+                var richException = new JsonFormatException(e, debugKey, typeof(TJson));
                 Console.WriteLine(richException);
                 throw richException;
             }

--- a/JsonMerging/JsonParsingUtils.cs
+++ b/JsonMerging/JsonParsingUtils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
+using InteractionsPlus.Exceptions;
 using InteractionsPlus.JetBrains.Annotations;
 using LitJson;
 
@@ -109,10 +110,8 @@ namespace InteractionsPlus.JsonMerging
         {
             InteractionsPlusMod.Services.TryResolve(out logger);
             var additionalJsonPath = Path.Combine(modPath, jsonPath);
-            //logger?.Log($"Modpath {modPath} jsonPath{jsonPath} merged {additionalJsonPath}");
             if (!File.Exists(additionalJsonPath))
             {
-                //logger?.Error($"Missing file {additionalJsonPath}");
                 return;
             }
 
@@ -144,8 +143,20 @@ namespace InteractionsPlus.JsonMerging
                 }
                 
                 var key = parsedJsonData["strName"].ToString();
-                logger?.Log($"Add data {key}");
-                appendDelegate(key, JsonMapper.ToObject<TJson>(parsedJsonData.ToJson()));
+                
+                TJson typedJson;
+                try
+                {
+                    typedJson = JsonMapper.ToObject<TJson>(parsedJsonData.ToJson());
+                    appendDelegate(key, typedJson);
+                }
+                catch (Exception e)
+                {
+                    var richException = new JsonFormatException(e, key, typeof(TJson));
+                    Console.WriteLine(richException);
+                    throw richException;
+                }
+                
             }
         }
         

--- a/JsonMerging/PostProcessedDataSource.cs
+++ b/JsonMerging/PostProcessedDataSource.cs
@@ -1,12 +1,16 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace InteractionsPlus.JsonMerging
 {
-    internal class PostProcessedDataSource : SimplePostfixOnlyDataSource
+    internal interface PostProcessedDataSource : JsonDataSource { }
+    
+    internal class PostProcessedDataSource<TJson> : SimplePostfixOnlyDataSource<TJson>, PostProcessedDataSource
     {
         public readonly string PostProcessMethodName;
 
-        public PostProcessedDataSource(string path, Type type, Action<string, object> appendAction, string postProcessMethodName) : base(path, type, appendAction)
+        public PostProcessedDataSource([NotNull] ILogger logger, [NotNull] string path, [NotNull] string postProcessMethodName, [NotNull] string dictionaryName, 
+        [NotNull] DataHandlerDictionaryAccessor accessor) : base(logger, path, dictionaryName, accessor)
         {
             PostProcessMethodName = postProcessMethodName;
         }

--- a/JsonMerging/SimplePostFixTempDictionarySource.cs
+++ b/JsonMerging/SimplePostFixTempDictionarySource.cs
@@ -1,0 +1,11 @@
+﻿using InteractionsPlus.JetBrains.Annotations;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal class SimplePostFixTempDictionarySource<TJson> : TempDictionarySource<TJson>, SimplePostfixOnlyDataSource
+    {
+        public SimplePostFixTempDictionarySource([NotNull] ILogger logger, [NotNull] string path) : base(logger, path)
+        {
+        }
+    }
+}

--- a/JsonMerging/SimplePostfixOnlyDataSource.cs
+++ b/JsonMerging/SimplePostfixOnlyDataSource.cs
@@ -1,19 +1,14 @@
-﻿using System;
+﻿using InteractionsPlus.JetBrains.Annotations;
 
 namespace InteractionsPlus.JsonMerging
 {
-    internal class SimplePostfixOnlyDataSource : JsonDataSource
+    internal interface SimplePostfixOnlyDataSource : JsonDataSource { }
+    
+    internal class SimplePostfixOnlyDataSource<TJson> : DataHandlerDictionarySource<TJson>, SimplePostfixOnlyDataSource
     {
-        public SimplePostfixOnlyDataSource(string path, Type type, Action<string, object> appendAction)
-            : base(path, type, appendAction)
+        public SimplePostfixOnlyDataSource([NotNull] ILogger logger, [NotNull] string path, [NotNull] string dictionaryName, 
+            [NotNull] DataHandlerDictionaryAccessor accessor) : base(logger, path, dictionaryName, accessor)
         {
-        }
-
-        protected override void ParseDataSource(string modPath)
-        {
-            var jsonPath = Path;
-            var parseDelegate = JsonParsingUtils.GetParseAdditionalJsonInPathAndAppendTypeless(JsonType);
-            parseDelegate(modPath,  jsonPath, AppendAction);
         }
     }
 }

--- a/JsonMerging/TempDictionarySource.cs
+++ b/JsonMerging/TempDictionarySource.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using InteractionsPlus.JetBrains.Annotations;
+using LitJson;
+
+namespace InteractionsPlus.JsonMerging
+{
+    internal abstract class TempDictionarySource<TJson> : JsonDataSource<TJson> 
+    {
+        public TempDictionarySource([NotNull] ILogger logger, [NotNull] string path) 
+            : base(logger, path)
+        {
+        }
+        
+        protected override void ParseDataSource(string modPath)
+        {
+            var jsonPath = Path;
+
+            if (!JsonParsingUtils.TryParseAdditionalJsonArrayInPath(modPath, jsonPath, out JsonData jsonArray))
+            {
+                return;
+            }
+            
+            Dictionary<string, TJson> dictionary = new Dictionary<string, TJson>();
+            Appender.ProcessJsonArray(dictionary, jsonArray);
+            dictionary.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Json objects with same "strName" fields were skipped during merging in previous iteration. Added support to define merge overrides to instruct on how to merge these objects.

If a mod provides a json object with same "strName" with an existing one, the appending process will check for additional properties with "*.override" key. Value of that property ("append", "remove", "overwrite") will be used as merging strategy, for the item. 

Example format

```json
{
    "strName" : ...,,
    "aCOs.override" : "append",
    "aCOs"    : [
      ...
    ],
    "aLoots.override" : "append",
    "aLoots"  : [
      ...
    ]
},
```


